### PR TITLE
Fix project memberships issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+Addresses xxxxxx (eg: #1 the-deep/questionnaire-builder-backend#1) \
+Depends on xxxxxx (eg: #1 the-deep/questionnaire-builder-backend#1)
+
+## Changes
+
+* Detailed list or prose of changes
+* Breaking changes
+* Changes to configurations
+
+**Mention related users here if any.**
+
+## This PR doesn't introduce any:
+
+- [ ] temporary files, auto-generated files or secret keys
+- [ ] n+1 queries
+- [ ] flake8 issues
+- [ ] `print`
+- [ ] typos
+- [ ] unwanted comments
+
+## This PR contains valid:
+
+- [ ] tests
+- [ ] permission checks (tests here too)
+- [ ] translations

--- a/apps/project/mutations.py
+++ b/apps/project/mutations.py
@@ -64,9 +64,9 @@ class ProjectScopeMutation(
     @strawberry.mutation
     async def update_memberships(
         self,
-        items: list[ProjectMembershipBulkMutation.PartialInputType] | None,
-        delete_ids: list[strawberry.ID] | None,
         info: Info,
+        items: list[ProjectMembershipBulkMutation.PartialInputType] | None = [],
+        delete_ids: list[strawberry.ID] | None = [],
     ) -> BulkMutationResponseType[ProjectMembershipType]:
         queryset = ProjectMembership.objects.filter(
             project=info.context.active_project.project,

--- a/apps/project/types.py
+++ b/apps/project/types.py
@@ -6,6 +6,7 @@ from strawberry.types import Info
 from utils.common import get_queryset_for_model
 from utils.strawberry.paginations import CountList, pagination_field
 from apps.common.types import ClientIdMixin, UserResourceTypeMixin
+from apps.user.types import UserType
 
 from .models import Project, ProjectMembership
 from .filters import ProjectMembershipFilter
@@ -34,6 +35,15 @@ class ProjectMembershipType(ClientIdMixin):
         return queryset.filter(
             project=info.context.active_project.project,
         )
+
+    @strawberry.field
+    def member(self, info: Info) -> UserType:
+        return info.context.dl.user.load_users.load(self.member_id)
+
+    @strawberry.field
+    def added_by(self, info: Info) -> UserType | None:
+        if self.added_by_id:
+            return info.context.dl.user.load_users.load(self.added_by_id)
 
 
 @strawberry_django.ordering.order(Project)

--- a/apps/user/filters.py
+++ b/apps/user/filters.py
@@ -1,5 +1,6 @@
 import strawberry
 import strawberry_django
+from strawberry.types import Info
 from django.db import models
 from django.db.models.functions import Concat
 
@@ -11,6 +12,7 @@ class UserFilter:
     id: strawberry.auto
     search: str | None
     members_exclude_project: strawberry.ID | None
+    exclude_me: bool = False
 
     def filter_search(self, queryset):
         value = self.search
@@ -36,4 +38,10 @@ class UserFilter:
             queryset = queryset.filter(
                 ~models.Q(projectmembership__project_id=value)
             ).distinct()
+        return queryset
+
+    def filter_exclude_me(self, queryset, info: Info):
+        value = self.exclude_me
+        if value:
+            queryset = queryset.exclude(id=info.context.request.user.id)
         return queryset

--- a/apps/user/filters.py
+++ b/apps/user/filters.py
@@ -10,6 +10,7 @@ from .models import User
 class UserFilter:
     id: strawberry.auto
     search: str | None
+    members_exclude_project: strawberry.ID | None
 
     def filter_search(self, queryset):
         value = self.search
@@ -27,4 +28,12 @@ class UserFilter:
                 models.Q(last_name__icontains=value) |
                 models.Q(email__icontains=value)
             )
+        return queryset
+
+    def filter_members_exclude_project(self, queryset):
+        value = self.members_exclude_project
+        if value:
+            queryset = queryset.filter(
+                ~models.Q(projectmembership__project_id=value)
+            ).distinct()
         return queryset

--- a/apps/user/filters.py
+++ b/apps/user/filters.py
@@ -1,0 +1,30 @@
+import strawberry
+import strawberry_django
+from django.db import models
+from django.db.models.functions import Concat
+
+from .models import User
+
+
+@strawberry_django.filters.filter(User, lookups=True)
+class UserFilter:
+    id: strawberry.auto
+    search: str | None
+
+    def filter_search(self, queryset):
+        value = self.search
+        if value:
+            queryset = queryset.annotate(
+                full_name=Concat(
+                    models.F("first_name"),
+                    models.Value(" "),
+                    models.F("last_name"),
+                    output_field=models.CharField(),
+                )
+            ).filter(
+                models.Q(full_name__icontains=value) |
+                models.Q(first_name__icontains=value) |
+                models.Q(last_name__icontains=value) |
+                models.Q(email__icontains=value)
+            )
+        return queryset

--- a/apps/user/mutations.py
+++ b/apps/user/mutations.py
@@ -5,7 +5,12 @@ from asgiref.sync import sync_to_async
 from django.contrib.auth import login, logout, update_session_auth_hash
 
 from utils.strawberry.transformers import generate_type_for_serializer
-from utils.strawberry.mutations import mutation_is_not_valid, MutationResponseType, MutationEmptyResponseType
+from utils.strawberry.mutations import (
+    process_input_data,
+    mutation_is_not_valid,
+    MutationResponseType,
+    MutationEmptyResponseType,
+)
 
 from .serializers import (
     LoginSerializer,
@@ -32,7 +37,7 @@ class PublicMutation:
     @strawberry.mutation
     @sync_to_async
     def register(self, data: RegisterInput, info: Info) -> MutationResponseType[UserMeType]:
-        serializer = RegisterSerializer(data=data.__dict__, context={'request': info.context.request})
+        serializer = RegisterSerializer(data=process_input_data(data), context={'request': info.context.request})
         if errors := mutation_is_not_valid(serializer):
             return MutationResponseType(
                 ok=False,
@@ -44,7 +49,7 @@ class PublicMutation:
     @strawberry.mutation
     @sync_to_async
     def login(self, data: LoginInput, info: Info) -> MutationResponseType[UserMeType]:
-        serializer = LoginSerializer(data=data.__dict__, context={'request': info.context.request})
+        serializer = LoginSerializer(data=process_input_data(data), context={'request': info.context.request})
         if errors := mutation_is_not_valid(serializer):
             return MutationResponseType(
                 ok=False,
@@ -67,7 +72,7 @@ class PublicMutation:
     @strawberry.mutation
     @sync_to_async
     def password_reset_trigger(self, data: PasswordResetTriggerInput, info: Info) -> MutationEmptyResponseType:
-        serializer = PasswordResetTriggerSerializer(data=data.__dict__, context={'request': info.context.request})
+        serializer = PasswordResetTriggerSerializer(data=process_input_data(data), context={'request': info.context.request})
         if errors := mutation_is_not_valid(serializer):
             return MutationEmptyResponseType(
                 ok=False,
@@ -79,7 +84,7 @@ class PublicMutation:
     @strawberry.mutation
     @sync_to_async
     def password_reset_confirm(self, data: PasswordResetConfirmInput, info: Info) -> MutationEmptyResponseType:
-        serializer = PasswordResetConfirmSerializer(data=data.__dict__, context={'request': info.context.request})
+        serializer = PasswordResetConfirmSerializer(data=process_input_data(data), context={'request': info.context.request})
         if errors := mutation_is_not_valid(serializer):
             return MutationEmptyResponseType(
                 ok=False,
@@ -95,7 +100,7 @@ class PrivateMutation:
     @strawberry.mutation
     @sync_to_async
     def change_user_password(self, data: PasswordChangeInput, info: Info) -> MutationEmptyResponseType:
-        serializer = PasswordChangeSerializer(data=data.__dict__, context={'request': info.context.request})
+        serializer = PasswordChangeSerializer(data=process_input_data(data), context={'request': info.context.request})
         if errors := mutation_is_not_valid(serializer):
             return MutationEmptyResponseType(
                 ok=False,
@@ -108,7 +113,7 @@ class PrivateMutation:
     @strawberry.mutation
     @sync_to_async
     def update_me(self, data: UserMeInput, info: Info) -> MutationResponseType[UserMeType]:
-        serializer = UserMeSerializer(data=data.__dict__, context={'request': info.context.request}, partial=True)
+        serializer = UserMeSerializer(data=process_input_data(data), context={'request': info.context.request}, partial=True)
         if errors := mutation_is_not_valid(serializer):
             return MutationResponseType(
                 ok=False,

--- a/apps/user/queries.py
+++ b/apps/user/queries.py
@@ -5,7 +5,7 @@ from strawberry.types import Info
 from asgiref.sync import sync_to_async
 from utils.strawberry.paginations import CountList, pagination_field
 
-from .types import UserType, UserMeType
+from .types import UserType, UserMeType, UserOrder
 from .filters import UserFilter
 
 
@@ -26,4 +26,5 @@ class PrivateQuery:
     users: CountList[UserType] = pagination_field(
         pagination=True,
         filters=UserFilter,
+        order=UserOrder,
     )

--- a/apps/user/queries.py
+++ b/apps/user/queries.py
@@ -3,8 +3,10 @@ import strawberry_django
 from strawberry.types import Info
 
 from asgiref.sync import sync_to_async
+from utils.strawberry.paginations import CountList, pagination_field
 
 from .types import UserType, UserMeType
+from .filters import UserFilter
 
 
 @strawberry.type
@@ -20,3 +22,8 @@ class PublicQuery:
 @strawberry.type
 class PrivateQuery:
     user: UserType = strawberry_django.field()
+
+    users: CountList[UserType] = pagination_field(
+        pagination=True,
+        filters=UserFilter,
+    )

--- a/apps/user/tests/test_queries.py
+++ b/apps/user/tests/test_queries.py
@@ -26,7 +26,7 @@ class TestUserQuery(TestCase):
         USERS = '''
             query MyQuery($filters: UserFilter) {
               private {
-                users(pagination: {limit: 10, offset: 0}, filters: $filters) {
+                users(order: {id: ASC}, pagination: {limit: 10, offset: 0}, filters: $filters) {
                   limit
                   offset
                   count
@@ -94,7 +94,9 @@ class TestUserQuery(TestCase):
             ({'search': '@vil'}, [user2]),
             ({'search': 'sample'}, [user1, user2]),
             ({'search': 'sample@'}, [user1, user2]),
-            ({'membersExcludeProject': str(project.pk)}, [user2, user3]),
+            ({'membersExcludeProject': str(project.pk)}, [self.user, user2, user3]),
+            ({}, [self.user, *self.users]),
+            ({'excludeMe': True}, self.users),
         ]:
             content = self.query_check(self.Query.USERS, variables={'filters': filters})
             assert content['data']['private']['users'] == {

--- a/apps/user/tests/test_queries.py
+++ b/apps/user/tests/test_queries.py
@@ -1,7 +1,9 @@
 from main.tests import TestCase
 
 from apps.user.models import User
+
 from apps.user.factories import UserFactory
+from apps.project.factories import ProjectFactory
 
 
 class TestUserQuery(TestCase):
@@ -74,7 +76,9 @@ class TestUserQuery(TestCase):
         )
 
     def test_users(self):
+        project = ProjectFactory.create()
         user1, user2, user3 = self.users
+        project.add_member(user1)
 
         # Without authentication -----
         content = self.query_check(self.Query.USERS, assert_errors=True)
@@ -90,6 +94,7 @@ class TestUserQuery(TestCase):
             ({'search': '@vil'}, [user2]),
             ({'search': 'sample'}, [user1, user2]),
             ({'search': 'sample@'}, [user1, user2]),
+            ({'membersExcludeProject': str(project.pk)}, [user2, user3]),
         ]:
             content = self.query_check(self.Query.USERS, variables={'filters': filters})
             assert content['data']['private']['users'] == {

--- a/apps/user/tests/test_queries.py
+++ b/apps/user/tests/test_queries.py
@@ -76,8 +76,8 @@ class TestUserQuery(TestCase):
         )
 
     def test_users(self):
-        project = ProjectFactory.create()
         user1, user2, user3 = self.users
+        project = ProjectFactory.create(created_by=user1, modified_by=user1)
         project.add_member(user1)
 
         # Without authentication -----

--- a/apps/user/types.py
+++ b/apps/user/types.py
@@ -4,6 +4,11 @@ from .models import User
 from .enums import OptEmailNotificationTypeEnum
 
 
+@strawberry_django.ordering.order(User)
+class UserOrder:
+    id: strawberry.auto
+
+
 @strawberry_django.type(User)
 class UserType:
     id: strawberry.ID

--- a/schema.graphql
+++ b/schema.graphql
@@ -88,7 +88,7 @@ type PrivateMutation {
 
 type PrivateQuery {
   user: UserType!
-  users(filters: UserFilter, pagination: OffsetPaginationInput): UserTypeCountList!
+  users(filters: UserFilter, order: UserOrder, pagination: OffsetPaginationInput): UserTypeCountList!
   projects(filters: ProjectFilter, order: ProjectOrder, pagination: OffsetPaginationInput): ProjectTypeCountList!
   projectScope(pk: ID!): ProjectScopeType
   id: ID!
@@ -272,6 +272,7 @@ input UserFilter {
   id: IDFilterLookup
   search: String
   membersExcludeProject: ID
+  excludeMe: Boolean = false
 }
 
 input UserMeInput {
@@ -293,6 +294,10 @@ type UserMeTypeMutationResponseType {
   ok: Boolean!
   errors: CustomErrorType
   result: UserMeType
+}
+
+input UserOrder {
+  id: Ordering
 }
 
 type UserType {

--- a/schema.graphql
+++ b/schema.graphql
@@ -123,7 +123,9 @@ type ProjectMembershipType {
   joinedAt: DateTime!
   memberId: ID!
   addedById: ID
+  addedBy: UserType
   clientId: String!
+  member: UserType!
 }
 
 type ProjectMembershipTypeBulkMutationResponseType {
@@ -140,10 +142,10 @@ type ProjectMembershipTypeCountList {
 }
 
 input ProjectMembershipUpdateInput {
-  id: ID = null
-  clientId: String = ""
-  member: ID = null
-  role: ProjectMembershipRoleTypeEnum = null
+  id: ID
+  clientId: String
+  member: ID
+  role: ProjectMembershipRoleTypeEnum
 }
 
 input ProjectOrder {
@@ -158,7 +160,7 @@ type ProjectScopeMutation {
   deleteQuestionnaire(id: ID!): QuestionnaireTypeListMutationResponseType!
   updateProject(data: ProjectUpdateInput!): ProjectTypeMutationResponseType!
   leaveProject(confirmPassword: String!): MutationEmptyResponseType!
-  updateMemberships(items: [ProjectMembershipUpdateInput!], deleteIds: [ID!]): ProjectMembershipTypeBulkMutationResponseType!
+  updateMemberships(items: [ProjectMembershipUpdateInput!] = [], deleteIds: [ID!] = []): ProjectMembershipTypeBulkMutationResponseType!
 }
 
 type ProjectScopeType {
@@ -193,7 +195,7 @@ type ProjectTypeMutationResponseType {
 }
 
 input ProjectUpdateInput {
-  title: String = ""
+  title: String
 }
 
 type PublicMutation {
@@ -255,20 +257,20 @@ type QuestionnaireTypeMutationResponseType {
 }
 
 input QuestionnaireUpdateInput {
-  title: String = ""
+  title: String
 }
 
 input RegisterInput {
   email: String!
   captcha: String!
-  firstName: String = ""
-  lastName: String = ""
+  firstName: String
+  lastName: String
 }
 
 input UserMeInput {
-  firstName: String = ""
-  lastName: String = ""
-  emailOptOuts: [OptEmailNotificationTypeEnum!] = null
+  firstName: String
+  lastName: String
+  emailOptOuts: [OptEmailNotificationTypeEnum!]
 }
 
 type UserMeType {

--- a/schema.graphql
+++ b/schema.graphql
@@ -88,6 +88,7 @@ type PrivateMutation {
 
 type PrivateQuery {
   user: UserType!
+  users(filters: UserFilter, pagination: OffsetPaginationInput): UserTypeCountList!
   projects(filters: ProjectFilter, order: ProjectOrder, pagination: OffsetPaginationInput): ProjectTypeCountList!
   projectScope(pk: ID!): ProjectScopeType
   id: ID!
@@ -267,6 +268,11 @@ input RegisterInput {
   lastName: String
 }
 
+input UserFilter {
+  id: IDFilterLookup
+  search: String
+}
+
 input UserMeInput {
   firstName: String
   lastName: String
@@ -293,4 +299,11 @@ type UserType {
   firstName: String!
   lastName: String!
   displayName: String!
+}
+
+type UserTypeCountList {
+  limit: Int!
+  offset: Int!
+  count: Int!
+  items: [UserType!]!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -271,6 +271,7 @@ input RegisterInput {
 input UserFilter {
   id: IDFilterLookup
   search: String
+  membersExcludeProject: ID
 }
 
 input UserMeInput {

--- a/utils/strawberry/enums.py
+++ b/utils/strawberry/enums.py
@@ -28,15 +28,15 @@ def get_enum_name_from_django_field(
             return type(_field.parent).__name__
 
     if field_name is None or model_name is None:
-        if type(field) == models.query_utils.DeferredAttribute:
+        if isinstance(field, models.query_utils.DeferredAttribute):
             return get_enum_name_from_django_field(
                 field.field,
                 field_name=field_name,
                 model_name=model_name,
                 serializer_name=serializer_name,
             )
-        if type(field) == serializers.ChoiceField:
-            if type(field.parent) == serializers.ListField:
+        if isinstance(field, serializers.ChoiceField):
+            if isinstance(field.parent, serializers.ListField):
                 if _have_model(field.parent.parent):
                     model_name = model_name or field.parent.parent.Meta.model.__name__
                 serializer_name = _get_serializer_name(field.parent)
@@ -46,17 +46,17 @@ def get_enum_name_from_django_field(
                     model_name = model_name or field.parent.Meta.model.__name__
                 serializer_name = _get_serializer_name(field)
                 field_name = field_name or field.field_name
-        elif type(field) == ArrayField:
+        elif isinstance(field, ArrayField):
             if _have_model(field):
                 model_name = model_name or field.model.__name__
             serializer_name = _get_serializer_name(field)
             field_name = field_name or field.base_field.name
-        elif type(field) in [
+        elif isinstance(field, (
             models.CharField,
             models.SmallIntegerField,
             models.IntegerField,
             models.PositiveSmallIntegerField,
-        ]:
+        )):
             if _have_model(field):
                 model_name = model_name or field.model.__name__
             serializer_name = _get_serializer_name(field)

--- a/utils/strawberry/mutations.py
+++ b/utils/strawberry/mutations.py
@@ -28,6 +28,17 @@ CustomErrorType = strawberry.scalar(
 )
 
 
+def process_input_data(data) -> dict:
+    """
+    Return dict from Strawberry Input Object
+    """
+    return {
+        key: value
+        for key, value in data.__dict__.items()
+        if value != strawberry.UNSET
+    }
+
+
 @strawberry.type
 class ArrayNestedErrorType:
     client_id: str
@@ -261,7 +272,7 @@ class ModelMutation:
             return MutationResponseType(ok=False, errors=errors)
         errors, saved_instance = await self.handle_mutation(
             self.serializer_class,
-            data.__dict__,
+            process_input_data(data),
             info,
         )
         if errors:
@@ -279,7 +290,7 @@ class ModelMutation:
             return MutationResponseType(ok=False, errors=errors)
         errors, saved_instance = await self.handle_mutation(
             self.serializer_class,
-            data.__dict__,
+            process_input_data(data),
             info,
             instance=instance,
             partial=True,
@@ -327,7 +338,7 @@ class ModelMutation:
         # Create/Update - Then
         results = []
         for data in items or []:
-            _data = data.__dict__
+            _data = process_input_data(data)
             _id = _data.pop('id', None)
             instance = None
             if _id:

--- a/utils/strawberry/transformers.py
+++ b/utils/strawberry/transformers.py
@@ -193,10 +193,7 @@ def convert_serializer_field(field, convert_choices_to_enum=True, force_optional
 
     if not is_required:
         if 'default' not in kwargs or 'default_factory' not in kwargs:
-            if graphql_type == str:
-                kwargs['default'] = ''
-            else:
-                kwargs['default'] = None
+            kwargs['default'] = strawberry.UNSET
         graphql_type = typing.Optional[graphql_type]
 
     return graphql_type, StrawberryField(


### PR DESCRIPTION
Addresses 
> 1. Adding a new member to a project
    - There's no way to fetch member's details (name, for instance) (Maybe we need a query to fetch all the users?)
> 2. Editing role of existing membership
    - Cannot update. Error: "Membership already exists."

## Changes

- Add UNSET default value for partial fields
- Allow skip value
- Add user data in the membership response
- Add pull request template _Same as this one_


## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
- [ ] translations
